### PR TITLE
Device string args

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -231,6 +231,15 @@ SoapySDRPlay::SoapySDRPlay(const SoapySDR::Kwargs &args)
         chParams->rspDuoTunerParams.rfDabNotchEnable = 0;
     }
 
+    // process additional device string arguments
+    for (std::pair<std::string, std::string> arg : args) {
+        // ignore 'driver', 'label', and 'soapy'
+        if (arg.first == "driver" || arg.first == "label" || arg.first == "soapy") {
+            continue;
+        }
+        writeSetting(arg.first, arg.second);
+    }
+
     _streams[0] = 0;
     _streams[1] = 0;
     useShort = true;
@@ -1414,6 +1423,7 @@ SoapySDR::ArgInfoList SoapySDRPlay::getSettingInfo(void) const
 void SoapySDRPlay::writeSetting(const std::string &key, const std::string &value)
 {
    std::lock_guard <std::mutex> lock(_general_state_mutex);
+SoapySDR_logf(SOAPY_SDR_INFO, "DEBUG - writeSetting(key=%s, value=%s)", key.c_str(), value.c_str());
 
 #ifdef RF_GAIN_IN_MENU
    if (key == "rfgain_sel")

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -489,6 +489,7 @@ SoapySDR_logf(SOAPY_SDR_INFO, "DEBUG - setAntenna(channel=%d, name=%s)", channel
             }
             else
             {
+                // preserve biasT setting when changing tuner/antenna
                 unsigned char biasTen = chParams->rspDuoTunerParams.biasTEnable;
                 releaseDevice();
                 device.tuner = device.tuner == sdrplay_api_Tuner_A ? sdrplay_api_Tuner_B : sdrplay_api_Tuner_A;

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -356,6 +356,7 @@ std::vector<std::string> SoapySDRPlay::listAntennas(const int direction, const s
 
 void SoapySDRPlay::setAntenna(const int direction, const size_t channel, const std::string &name)
 {
+SoapySDR_logf(SOAPY_SDR_INFO, "DEBUG - setAntenna(channel=%d, name=%s)", channel, name.c_str());
     // Check direction
     if ((direction != SOAPY_SDR_RX) || (device.hwVer == SDRPLAY_RSP1_ID) || (device.hwVer == SDRPLAY_RSP1A_ID)) {
         return;       
@@ -1492,6 +1493,7 @@ SoapySDR_logf(SOAPY_SDR_INFO, "DEBUG - writeSetting(key=%s, value=%s)", key.c_st
       }
       else if (device.hwVer == SDRPLAY_RSPduo_ID)
       {
+SoapySDR_logf(SOAPY_SDR_INFO, "DEBUG - biasT - device.tuner=%d isRxChannelA=%d isRxChannelB=%d", device.tuner, chParams == deviceParams->rxChannelA, chParams == deviceParams->rxChannelB);
          chParams->rspDuoTunerParams.biasTEnable = biasTen;
          if (streamActive)
          {

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -489,9 +489,11 @@ SoapySDR_logf(SOAPY_SDR_INFO, "DEBUG - setAntenna(channel=%d, name=%s)", channel
             }
             else
             {
+                unsigned char biasTen = chParams->rspDuoTunerParams.biasTEnable;
                 releaseDevice();
                 device.tuner = device.tuner == sdrplay_api_Tuner_A ? sdrplay_api_Tuner_B : sdrplay_api_Tuner_A;
                 selectDevice();
+                chParams->rspDuoTunerParams.biasTEnable = biasTen;
             }
         }
     }

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -356,7 +356,6 @@ std::vector<std::string> SoapySDRPlay::listAntennas(const int direction, const s
 
 void SoapySDRPlay::setAntenna(const int direction, const size_t channel, const std::string &name)
 {
-SoapySDR_logf(SOAPY_SDR_INFO, "DEBUG - setAntenna(channel=%d, name=%s)", channel, name.c_str());
     // Check direction
     if ((direction != SOAPY_SDR_RX) || (device.hwVer == SDRPLAY_RSP1_ID) || (device.hwVer == SDRPLAY_RSP1A_ID)) {
         return;       
@@ -1427,7 +1426,6 @@ SoapySDR::ArgInfoList SoapySDRPlay::getSettingInfo(void) const
 void SoapySDRPlay::writeSetting(const std::string &key, const std::string &value)
 {
    std::lock_guard <std::mutex> lock(_general_state_mutex);
-SoapySDR_logf(SOAPY_SDR_INFO, "DEBUG - writeSetting(key=%s, value=%s)", key.c_str(), value.c_str());
 
 #ifdef RF_GAIN_IN_MENU
    if (key == "rfgain_sel")
@@ -1496,7 +1494,6 @@ SoapySDR_logf(SOAPY_SDR_INFO, "DEBUG - writeSetting(key=%s, value=%s)", key.c_st
       }
       else if (device.hwVer == SDRPLAY_RSPduo_ID)
       {
-SoapySDR_logf(SOAPY_SDR_INFO, "DEBUG - biasT - device.tuner=%d isRxChannelA=%d isRxChannelB=%d", device.tuner, chParams == deviceParams->rxChannelA, chParams == deviceParams->rxChannelB);
          chParams->rspDuoTunerParams.biasTEnable = biasTen;
          if (streamActive)
          {


### PR DESCRIPTION
Process 'rfnotch_ctrl', 'dabnotch_ctrl', and 'biasT' device string arguments in the constructor (makes these settings available in applications like gqrx)